### PR TITLE
Update waveplus.yaml

### DIFF
--- a/etc/waveplus.yaml
+++ b/etc/waveplus.yaml
@@ -8,7 +8,7 @@
 timeout: 30
 
 # frequancy- how often to probe
-frequancy: 90
+frequency: 90
 
 # timestamp- put timestamps in the output
 timestamps: false


### PR DESCRIPTION
frequency was typed wrong. Therefore it always took default seconds and ignored the input in the YAML.